### PR TITLE
chore(ci): add GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -1,0 +1,35 @@
+name: Build and Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup update stable
+
+      - name: Build
+        run: cargo build --release
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup component add rustfmt clippy
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            name: kon-x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            name: kon-aarch64-apple-darwin
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: kon-x86_64-unknown-linux-gnu
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup target add ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/kon dist/
+          cd dist
+          tar -czvf ${{ matrix.name }}.tar.gz kon
+          shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: dist/${{ matrix.name }}.tar.gz*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        run: |
+          for file in artifacts/*; do
+            gh release upload ${{ github.ref_name }} "$file" --clobber
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ kon
 
 ![sample](./sample.gif)
 
+## Release
+
+```sh
+# 1. Update version in Cargo.toml
+# 2. Create and push tag
+git tag v0.1.2
+git push origin v0.1.2
+# 3. Download sha256 files from release assets
+# 4. Update version and sha256 in https://github.com/Doarakko/homebrew-tap/blob/main/Formula/kon.rb
+```
+
 ## Credit
 
 - [RandomFox](https://randomfox.ca/)


### PR DESCRIPTION
## Summary
- Add release workflow for cross-platform builds (x86_64/arm64 macOS, x86_64 Linux)
- Add build and lint workflow for PRs (cargo build, fmt, clippy)
- Add github-actions to dependabot
- Add release instructions to README

## Changes
- `.github/workflows/release.yml`: Build and release on tag push
- `.github/workflows/build-and-lint.yml`: CI checks on PR and main push
- `.github/dependabot.yml`: Add github-actions ecosystem
- `README.md`: Add release instructions

## Test plan
- [ ] Create a tag to verify release workflow
- [ ] Create a PR to verify build and lint workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated build and linting workflow triggered on pull requests and commits
  * Established release pipeline for building and publishing binaries across multiple platforms (macOS and Linux architectures)
  * Configured Dependabot for automated GitHub Actions dependency updates

* **Documentation**
  * Updated README with release preparation and publishing instructions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->